### PR TITLE
Fix code scanning alert by adding necessary permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  security-events: write
+
 jobs:
   call-dependabot:
     uses: Boomchainlab/.github/.github/workflows/dependabot-reusable.yml@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  security-events: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,6 +3,7 @@ name: Node.js CI/CD
 permissions:
   contents: read
   pull-requests: write
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Related to #5

Add `security-events: write` permission to workflow files to fix code scanning alert.

* **.github/workflows/dependabot.yml**
  - Add `security-events: write` permission under `permissions` section.

* **.github/workflows/deploy.yaml**
  - Add `security-events: write` permission under `permissions` section.

* **.github/workflows/nodejs.yml**
  - Add `security-events: write` permission under `permissions` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Boomchainlab/chonk9k/issues/5?shareId=XXXX-XXXX-XXXX-XXXX).