### PR TITLE
Update Replit config to use npm run build and npm run start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "tasks": {
     "build": "npm install && npm run build",
-    "test": "npm install && npm test"
+    "test": "npm install && npm test",
+    "launch": "npm install && npm run start"
   }
 }

--- a/.replit
+++ b/.replit
@@ -7,8 +7,8 @@ channel = "stable-24_05"
 
 [deployment]
 deploymentTarget = "autoscale"
-build = ["npm", "run", "build"]
-run = ["npm", "run", "start"]
+build = "npm run build"
+run = "npm run start"
 
 [[ports]]
 localPort = 5000

--- a/.replit
+++ b/.replit
@@ -1,5 +1,5 @@
 modules = ["nodejs-20", "web", "postgresql-16"]
-run = "npm run dev"
+run = "npm run start"
 hidden = [".config", ".git", "generated-icon.png", "node_modules", "dist"]
 
 [nix]


### PR DESCRIPTION
Update the `.replit` configuration file to modify the build and run commands.

* Change the `run` command from `npm run dev` to `npm run start`
* Ensure the `build` command is set to `npm run build`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Boomchainlab/chonk9k/pull/14?shareId=d21014be-f282-49c4-8b9c-d0a713552303).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Boomchainlab/chonk9k/14)
<!-- Reviewable:end -->
