### PR TITLE
Fix transfer function in CHONK9K contract

### DIFF
--- a/contracts/CHONK9K.sol
+++ b/contracts/CHONK9K.sol
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -28,21 +27,17 @@ contract CHONK9K is ERC20, Ownable {
         require(recipient != address(0), "Transfer to zero address");
 
         // Calculate fees
+        uint256 totalFee = (amount * (burnFee + devFee)) / FEE_DENOMINATOR;
         uint256 burnAmount = (amount * burnFee) / FEE_DENOMINATOR;
-        uint256 devAmount = (amount * devFee) / FEE_DENOMINATOR;
-        uint256 transferAmount = amount - burnAmount - devAmount;
+        uint256 transferAmount = amount - totalFee;
 
         // Transfer tokens
+        super._transfer(sender, address(0), burnAmount); // Burn
+        emit Burn(sender, burnAmount);
+
+        super._transfer(sender, owner(), totalFee - burnAmount); // Dev fee
+        emit DevFee(sender, owner(), totalFee - burnAmount);
+
         super._transfer(sender, recipient, transferAmount);
-
-        if (burnAmount > 0) {
-            _burn(sender, burnAmount); // Use `_burn` for clarity
-            emit Burn(sender, burnAmount);
-        }
-
-        if (devAmount > 0) {
-            super._transfer(sender, owner(), devAmount);
-            emit DevFee(sender, owner(), devAmount);
-        }
     }
 }


### PR DESCRIPTION
Update the `_transfer` function in `contracts/CHONK9K.sol` to correctly calculate and apply the burn fee, dev fee, and transfer amount.

* Calculate the total fee as `(amount * (burnFee + devFee)) / FEE_DENOMINATOR`.
* Calculate the burn amount as `(amount * burnFee) / FEE_DENOMINATOR`.
* Calculate the transfer amount as `amount - totalFee`.
* Transfer the burn amount to the zero address and emit a `Burn` event.
* Transfer the dev fee to the owner and emit a `DevFee` event.
* Transfer the remaining amount to the recipient.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Boomchainlab/chonk9k/pull/16?shareId=6ae6d779-2db0-4f43-88a1-488b85f13393).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Boomchainlab/chonk9k/16)
<!-- Reviewable:end -->
