### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CHONK9K CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Boomchainlab/chonk9k/security/code-scanning/39](https://github.com/Boomchainlab/chonk9k/security/code-scanning/39)

To fix the issue, add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow appears to be a CI pipeline, it likely only needs `contents: read` permissions. If additional permissions are required, they should be explicitly added based on the specific needs of the workflow.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Boomchainlab/chonk9k/100)
<!-- Reviewable:end -->
